### PR TITLE
Sms.php

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -40,7 +40,7 @@ class Base
      * @param array $params
      * @return resource
      */
-    public function connect(string $route, array $params = [], array $data = [])
+    public function connect($route, array $params = [], array $data = [])
     {
         $url  = "http://" . $this->goip->host . '/default/en_US';
         $url .= $route . '?' . http_build_query($params);

--- a/src/Sms.php
+++ b/src/Sms.php
@@ -46,17 +46,13 @@ class Sms extends Base
             ["type" => "sms_inbox"]
         );
 
-        preg_match_all('/sms\=\s\[[^\]]*\]/', $result, $lines);
-        foreach($lines[0] as $i => $data) {
+        preg_match_all('/sms\=\s(.*\]);/', $result, $lines);
+        foreach($lines[1] as $i => $data) {
             $line = $i + 1;
             $messages[$line] = [];
-            $data = str_replace('sms= [', '', $data);
-            $data = str_replace(']', '', $data);
-            $data = explode('",', $data);
-            foreach ($data as $key => $message) {
-                $message = ltrim($message, '"');
-                $message = rtrim($message, '"');
 
+            $data = json_decode($data);
+            foreach ($data as $message) {
                 if (empty($message)) {
                     continue;
                 }

--- a/src/Sms.php
+++ b/src/Sms.php
@@ -47,11 +47,16 @@ class Sms extends Base
         );
 
         preg_match_all('/sms\=\s(.*\]);/', $result, $lines);
-        foreach($lines[1] as $i => $data) {
+        foreach($lines[1] as $i => $dataRaw) {
             $line = $i + 1;
             $messages[$line] = [];
 
-            $data = json_decode($data);
+            $data = json_decode($dataRaw);
+            
+            if (is_null($data)) {
+                $dataRaw = iconv("UTF-8", "UTF-8//IGNORE", $dataRaw);
+                $data = json_decode($dataRaw);
+            }
             foreach ($data as $message) {
                 if (empty($message)) {
                     continue;


### PR DESCRIPTION
I had issue with goip-1 @ firmware GHSFVT-1.1-64-2, where in inbox I had trash text like '[SMS1 missed]' and current filters was working incorrect.
I had tested this code with goip-1 and goip-4.
![goip - waterfox 2018-10-05 18 43 03](https://user-images.githubusercontent.com/16125559/46550285-4d006800-c8dd-11e8-8d94-6349264f60a8.png)
![online regex tester and debugger_ php pcre python golang and javascript - waterfox 2018-10-05 18 50 57](https://user-images.githubusercontent.com/16125559/46550286-4d006800-c8dd-11e8-8fd1-4902d867b3f2.png)
![goip-php-api - d__work_php_mydev_goip-sms_goip-php-api - _examples_sms php - phpstorm 2016 2 1 2018-10-05 19 30 34](https://user-images.githubusercontent.com/16125559/46550287-4d006800-c8dd-11e8-8782-e7941a8995f6.png)
